### PR TITLE
Concentrate and default output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# default output location for generated files
+output/

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ boto3 = "*"
 gtfs-realtime-bindings = "*"
 protobuf = "*"
 protobuf3-to-dict = "*"
+requests = "*"
 
 [requires]
 python_version = "3"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "629a939441d18c7c5bd35c78384fe941c2b164275becfd130a425d52bbdd27a1"
+            "sha256": "1be7764c502115dda95178e9bc1c613994c698a3e58e5fefb4dabdc76a28353b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,32 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:883f7143bcb081a834f7c09659524059b66745ea043fffd40420e88ef0143feb",
-                "sha256:9c789a775f0499743b083ffd63e0e87dae9a727511bb37f2529da52ccd25a360"
+                "sha256:09b82fe8c0e5a73cb0406c137869ad2bb0d307513a4a43f993217b25bab4857a",
+                "sha256:f3cfeadcf864730e8ac7934393eada5d398710b23e37ac66ade11fd5544acff9"
             ],
             "index": "pypi",
-            "version": "==1.9.134"
+            "version": "==1.9.139"
         },
         "botocore": {
             "hashes": [
-                "sha256:5c4d9ea1b0fbb1dc98b6a06ed8780096fca981a1c3599bf8f03f338e6aa389ae",
-                "sha256:c59a74539eb081f4b3a307fc5c3d69d8459e30bfaf4b94aa78e74a9a05583764"
+                "sha256:36779f02ce5e4568bb718edde9c4095d187e5f47fb840a640ddf3f33e163c80f",
+                "sha256:abb07082f80c6a487236cb488492258df4a97365cf63e091c79f4c7b202469e5"
             ],
-            "version": "==1.12.134"
+            "version": "==1.12.139"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+            ],
+            "version": "==2019.3.9"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
         },
         "docutils": {
             "hashes": [
@@ -45,6 +59,13 @@
             ],
             "index": "pypi",
             "version": "==0.0.5"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
         },
         "jmespath": {
             "hashes": [
@@ -99,6 +120,14 @@
             ],
             "index": "pypi",
             "version": "==2019.1"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
         },
         "s3transfer": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,18 +18,18 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:63cd957ba663f5c10ff48ed904575eaa701314f79f18dbc59bd050311cd5f809",
-                "sha256:d1338582bc58741f54bd6b43488de6097a82ea45cebed0a3fd936981eadbb3a5"
+                "sha256:883f7143bcb081a834f7c09659524059b66745ea043fffd40420e88ef0143feb",
+                "sha256:9c789a775f0499743b083ffd63e0e87dae9a727511bb37f2529da52ccd25a360"
             ],
             "index": "pypi",
-            "version": "==1.9.86"
+            "version": "==1.9.134"
         },
         "botocore": {
             "hashes": [
-                "sha256:24444e7580f0114c3e9fff5d2032c6f0cfbf88691b1be3ba27c6922507a902ec",
-                "sha256:5b01a16f02c3da55068b3aacfa1c37dd8e17141551e1702424b38dd21fa1c792"
+                "sha256:5c4d9ea1b0fbb1dc98b6a06ed8780096fca981a1c3599bf8f03f338e6aa389ae",
+                "sha256:c59a74539eb081f4b3a307fc5c3d69d8459e30bfaf4b94aa78e74a9a05583764"
             ],
-            "version": "==1.12.86"
+            "version": "==1.12.134"
         },
         "docutils": {
             "hashes": [
@@ -48,32 +48,34 @@
         },
         "jmespath": {
             "hashes": [
-                "sha256:6a81d4c9aa62caf061cb517b4d9ad1dd300374cd4706997aff9cd6aedd61fc64",
-                "sha256:f11b4461f425740a1d908e9a3f7365c3d2e569f6ca68a2ff8bc5bcd9676edd63"
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
             ],
-            "version": "==0.9.3"
+            "version": "==0.9.4"
         },
         "protobuf": {
             "hashes": [
-                "sha256:10394a4d03af7060fa8a6e1cbf38cea44be1467053b0aea5bbfcb4b13c4b88c4",
-                "sha256:1489b376b0f364bcc6f89519718c057eb191d7ad6f1b395ffd93d1aa45587811",
-                "sha256:1931d8efce896981fe410c802fd66df14f9f429c32a72dd9cfeeac9815ec6444",
-                "sha256:196d3a80f93c537f27d2a19a4fafb826fb4c331b0b99110f985119391d170f96",
-                "sha256:46e34fdcc2b1f2620172d3a4885128705a4e658b9b62355ae5e98f9ea19f42c2",
-                "sha256:4b92e235a3afd42e7493b281c8b80c0c65cbef45de30f43d571d1ee40a1f77ef",
-                "sha256:574085a33ca0d2c67433e5f3e9a0965c487410d6cb3406c83bdaf549bfc2992e",
-                "sha256:59cd75ded98094d3cf2d79e84cdb38a46e33e7441b2826f3838dcc7c07f82995",
-                "sha256:5ee0522eed6680bb5bac5b6d738f7b0923b3cafce8c4b1a039a6107f0841d7ed",
-                "sha256:65917cfd5da9dfc993d5684643063318a2e875f798047911a9dd71ca066641c9",
-                "sha256:685bc4ec61a50f7360c9fd18e277b65db90105adbf9c79938bd315435e526b90",
-                "sha256:92e8418976e52201364a3174e40dc31f5fd8c147186d72380cbda54e0464ee19",
-                "sha256:9335f79d1940dfb9bcaf8ec881fb8ab47d7a2c721fb8b02949aab8bbf8b68625",
-                "sha256:a7ee3bb6de78185e5411487bef8bc1c59ebd97e47713cba3c460ef44e99b3db9",
-                "sha256:ceec283da2323e2431c49de58f80e1718986b79be59c266bb0509cbf90ca5b9e",
-                "sha256:fcfc907746ec22716f05ea96b7f41597dfe1a1c088f861efb8a0d4f4196a6f10"
+                "sha256:21e395d7959551e759d604940a115c51c6347d90a475c9baf471a1a86b5604a9",
+                "sha256:57e05e16955aee9e6a0389fcbd58d8289dd2420e47df1a1096b3a232c26eb2dd",
+                "sha256:67819e8e48a74c68d87f25cad9f40edfe2faf278cdba5ca73173211b9213b8c9",
+                "sha256:75da7d43a2c8a13b0bc7238ab3c8ae217cbfd5979d33b01e98e1f78defb2d060",
+                "sha256:78e08371e236f193ce947712c072542ff19d0043ab5318c2ea46bbc2aaebdca6",
+                "sha256:7ee5b595db5abb0096e8c4755e69c20dfad38b2d0bcc9bc7bafc652d2496b471",
+                "sha256:86260ecfe7a66c0e9d82d2c61f86a14aa974d340d159b829b26f35f710f615db",
+                "sha256:92c77db4bd33ea4ee5f15152a835273f2338a5246b2cbb84bab5d0d7f6e9ba94",
+                "sha256:9c7b90943e0e188394b4f068926a759e3b4f63738190d1ab3d500d53b9ce7614",
+                "sha256:a77f217ea50b2542bae5b318f7acee50d9fc8c95dd6d3656eaeff646f7cab5ee",
+                "sha256:ad589ed1d1f83db22df867b10e01fe445516a5a4d7cfa37fe3590a5f6cfc508b",
+                "sha256:b06a794901bf573f4b2af87e6139e5cd36ac7c91ac85d7ae3fe5b5f6fc317513",
+                "sha256:bd8592cc5f8b4371d0bad92543370d4658dc41a5ccaaf105597eb5524c616291",
+                "sha256:be48e5a6248a928ec43adf2bea037073e5da692c0b3c10b34f9904793bd63138",
+                "sha256:cc5eb13f5ccc4b1b642cc147c2cdd121a34278b341c7a4d79e91182fff425836",
+                "sha256:cd3b0e0ad69b74ee55e7c321f52a98effed2b4f4cc9a10f3683d869de00590d5",
+                "sha256:d6e88c4920660aa75c0c2c4b53407aef5efd9a6e0ca7d2fc84d79aba2ccbda3a",
+                "sha256:ec3c49b6d247152e19110c3a53d9bb4cf917747882017f70796460728b02722e"
             ],
             "index": "pypi",
-            "version": "==3.6.1"
+            "version": "==3.7.1"
         },
         "protobuf3-to-dict": {
             "hashes": [
@@ -84,26 +86,26 @@
         },
         "python-dateutil": {
             "hashes": [
-                "sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93",
-                "sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02"
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
             ],
             "markers": "python_version >= '2.7'",
-            "version": "==2.7.5"
+            "version": "==2.8.0"
         },
         "pytz": {
             "hashes": [
-                "sha256:32b0891edff07e28efe91284ed9c31e123d84bea3fd98e1f72be2508f43ef8d9",
-                "sha256:d5f05e487007e29e03409f9398d074e158d920d36eb82eaf66fb1136b0c5374c"
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
             ],
             "index": "pypi",
-            "version": "==2018.9"
+            "version": "==2019.1"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:90dc18e028989c609146e241ea153250be451e05ecc0c2832565231dacdf59c1",
-                "sha256:c7a9ec356982d5e9ab2d4b46391a7d6a950e2b04c472419f5fdec70cc0ada72f"
+                "sha256:7b9ad3213bff7d357f888e0fab5101b56fa1a0548ee77d121c3a3dbfbef4cb2e",
+                "sha256:f23d5cb7d862b104401d9021fc82e5fa0e0cf57b7660a1331425aab0c691d021"
             ],
-            "version": "==0.1.13"
+            "version": "==0.2.0"
         },
         "six": {
             "hashes": [
@@ -114,11 +116,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
-                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+                "sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0",
+                "sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3"
             ],
             "markers": "python_version >= '3.4'",
-            "version": "==1.24.1"
+            "version": "==1.24.2"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -27,17 +27,18 @@ Bucket name is shared on LastPass
 
 #### Usage
 
-`pipenv run python3 getArchive.py --datetime [YYYY-MM-DDTHH:mm] --output [output file location]`
+`pipenv run python3 getArchive.py --datetime [YYYY-MM-DDTHH:mm]`
 
 ###### Optional arguments
 
-|       Argument       |                                          Description                                          |
-| -------------------- | --------------------------------------------------------------------------------------------- |
-| `--stop [stop id]`   | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
-| `--route [route id]` | Use to only include trip_updates affecting the given route                                    |
-| `--trip [trip id]`   | Use to only include a specific trip_id                                                        |
-| `--feed [name]`      | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `winthrop`, `concentrate` |
-| `--raw`              | Download the file directly, without filtering or processing                                   |
+|        Argument       |                                          Description                                          |
+| --------------------- | --------------------------------------------------------------------------------------------- |
+| `--stop [stop id]`    | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
+| `--route [route id]`  | Use to only include trip_updates affecting the given route                                    |
+| `--trip [trip id]`    | Use to only include a specific trip_id                                                        |
+| `--feed [name]`       | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `winthrop`, `concentrate` |
+| `--raw`               | Download the file directly, without filtering or processing                                   |
+| `--output [filepath]` | Where to create the output file (default is `prediction-loc/output/[datetime].json`)          |
 
 * Note: route_id is matched exactly for the `bus` and `concentrate` feeds, but does fuzzy matching for all others.
 For example, `--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Bucket name is shared on LastPass
 | `--trip [trip id]`    | Use to only include a specific trip_id                                                        |
 | `--feed [name]`       | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `winthrop`, `concentrate` |
 | `--raw`               | Download the file directly, without filtering or processing                                   |
-| `--output [filepath]` | Where to create the output file (default is `prediction-loc/output/[datetime].json`)          |
+| `--output [filepath]` | Where to create the output file (default is `prediction-loc/output/[feed]-[datetime].json`)   |
 
 * Note: route_id is matched exactly for the `bus` and `concentrate` feeds, but does fuzzy matching for all others.
 For example, `--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ Bucket name is shared on LastPass
 
 ###### Optional arguments
 
-|       Argument       |                                    Description                                    |
-| -------------------- | --------------------------------------------------------------------------------- |
-| `--stop [stop id]`   | Use to only include trip_updates affecting the given (comma-separated) stop_id(s) |
-| `--route [route id]` | Use to only include trip_updates affecting the given route                        |
-| `--trip [trip id]`   | Use to only include a specific trip_id                                            |
-| `--feed [name]`      | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `winthrop`    |
-| `--raw`              | Download the file directly, without filtering or processing                       |
+|       Argument       |                                          Description                                          |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `--stop [stop id]`   | Use to only include trip_updates affecting the given (comma-separated) stop_id(s)             |
+| `--route [route id]` | Use to only include trip_updates affecting the given route                                    |
+| `--trip [trip id]`   | Use to only include a specific trip_id                                                        |
+| `--feed [name]`      | Feed to retrieve. Accepted values: `bus` (default), `subway`, `cr`, `winthrop`, `concentrate` |
+| `--raw`              | Download the file directly, without filtering or processing                                   |
 
-* Note: route_id is matched exactly for the bus feed, but does fuzzy matching for all others. For example,
-`--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id
+* Note: route_id is matched exactly for the `bus` and `concentrate` feeds, but does fuzzy matching for all others.
+For example, `--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id
 `CR-Worcester`
 
 #### Troubleshooting


### PR DESCRIPTION
* Accepts Concentrate feed argument (`--feed concentrate`)
* No longer requires an `--output` argument and instead defaults to `prediction-loc/output/` with the filename being the same as the `--datetime` argument.
* Updates dependencies to address a vulnerability in `urllib3` version 1.24.1