### PR TITLE
docs(readme): add JQ example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ pipenv run getArchive --datetime $(date -Iminutes -v -1m -v -1d)
 
 **Note:** route_id is matched exactly for the `bus` and `concentrate` feeds, but does substring matching for all others. For example, `--route Green` will include all Green Line branches, and `--route Worcester` will still match route_id `CR-Worcester`.
 
+### Using JQ to wrangle the output
+
+You can use the [jq](https://jqlang.org/) JSON processing language to answer many questions about the data. For example, if you wanted to find all trip updates for a given vehicle:
+```bash
+cat feed.json | jq -c '.entity | .[] | select(.trip_update.vehicle.id == "foo")' | jq
+```
+
+This searches for all vehicles with a vehicle ID of `foo` within `feed.json`.
+
 ### Troubleshooting
 
 If the `aws` command cannot be found, you will need to add it to your `PATH`:


### PR DESCRIPTION
Problem:
There are lots of questions about RT data that involve ad-hoc manipulation / selection of some attributes. Building all of these filters / transformations into `prediction_loc` would be time-prohibitive

Solution:
Add an example for how to use `jq` to query the JSON data. We can use this section to collect short JQ commands that cover useful scenarios.